### PR TITLE
Fix: client/import.yml acls directory

### DIFF
--- a/client/import.yml
+++ b/client/import.yml
@@ -9,7 +9,7 @@ keys:
 
 acls:
   - name: UserAccess.aclpolicy
-    file: data/user.aclpolicy
+    file: acls/user.aclpolicy
 
 users:
   - username: alice


### PR DESCRIPTION
Fixed directory not found when importing acls from the client container:

```yaml
acls:
  - name: UserAccess.aclpolicy
    file: acls/user.aclpolicy
```

Current error is:
```bash
importing acls
----------------------------------
importing acls UserAccess.aclpolicy
from file: /app/data/data/user.aclpolicy

Error importing aclsUserAccess.aclpolicy:Error: ENOENT: no such file or directory, open '/app/data/data/user.aclpolicy'
```

Output after fix:
```bash
importing acls
----------------------------------
importing acls UserAccess.aclpolicy
from file: /app/data/acls/user.aclpolicy
```
